### PR TITLE
fix duplicate pause screen entry

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -10,10 +10,8 @@
     "showPromo": true
   },
   "pauseScreen": {
-    "showPlayButton" : true
-  },
-  "pauseScreen": {
-    "screenToShowOnPause": "discovery",
+    "showPlayButton" : true,
+    "screenToShowOnPause": "discovery"
   },
   "endScreen": {
     "screenToShowOnEnd": "discovery",


### PR DESCRIPTION
For some reason we overlooked the fact that there were two pause screen entries in the skin.json file.
