### PR TITLE
Abstract buttons

### DIFF
--- a/skin-schema.json
+++ b/skin-schema.json
@@ -50,16 +50,24 @@
         "title" : { "type" : "string" }
       }
     },
-    "controlBar" : {
-      "description" : "The playback control bar. Generally contains a play-pause button, scrubber control, etc.",
+    "buttons" : {
+      "description" : "Defines the buttons that can appear on the controlBar and/or the moreOptions panel.",
       "type" : "object",
+      "additionalProperties" : false,
+      "required" : ["desktop", "mobile"],
       "properties" : {
+        "desktop" : { "$ref" : "#/definitions/buttonArray" },
+        "mobile" : { "$ref" : "#/definitions/buttonArray" }
+      }
+    },
+    "controlBar" : {
+      "description" : "The playback control bar. Generally contains a play-pause button, scrubber control, etc. The set of items to show comes from the 'buttons' part of the schema.",
+      "type" : "object",
+      "additionalProperties" : false,
+      "required" : [ "height", "autoHide", "watermark" ],
+      "properties" : {
+        "height" : { "type" : "number" },
         "autoHide" : { "type" : "boolean" },
-        "items" : {
-          "description" : "The list of buttons to (maximally) show, in left-to-right order. For watermark, we recommend 30px height and less then 120px width for desktop, (??? for mobile), which is the default size for OOYALA logo.",
-          "type" : "array",
-          "items" : { "$ref" : "#/definitions/button" }
-        },
         "watermark": {
           "type": "object",
           "additionalProperties" : false,
@@ -105,20 +113,18 @@
       }
     },
     "moreOptions": {
+      "description" : "The more options / overflow panel. The set of items to show comes from the 'buttons' part of the schema.",
       "type": "object",
+      "required" : ["iconSize", "color"], // TODO: anything else? Are there defaults in code for the opacities?
+      "additionalProperties" : false,
+      "patternProperties" : {
+        "brightOpacity": {"type": "number"},
+        "darkOpacity": {"type": "number"}
+      },
       "properties": {
-        "brightOpacitiy": {"type": "number"},
-        "darkOpacity": {"type": "number"},
         "iconSize": {"type": "number"},
-        "color": {"type": "string"},
-        "buttons": {
-          "type": "array",
-          "items": {
-            // TODO: change to using the button schema, like the control bar items.
-            "enum" : ["discovery", "quality", "closedCaption", "share", "settings"]
-          }
-        }
-      }            
+        "color": {"type": "string"}
+      }
     },
     "discoveryScreen" : {
       "type" : "object",
@@ -176,28 +182,25 @@
       }
     },
     "button" : {
-      "description" : "Specify a button that appears in the user interface.",
+      "description" : "Specify a button that appears in the user interface. See the buttons, controlBar, and moreOptions part of the schema.",
       "type" : "object",
-      "required" : ["name", "collapsable", "webMinWidth", "sdkMinWidth"],
-      "additionalProperties" : false,
       "properties" : {
         "name" : {
-          "description" : "These are the currently supported buttons. Each implementation in JavaScript knows how to render itself.",
+          "description" : "These are the only buttons currently supported by the UI SDK.",
           "enum" : ["playPause", "volume", "timeDuration", "flexibleSpace", "discovery", "fullscreen", "moreOptions", "watermark", "share", "closedCaption", "bitrateSelector", "quality"]
         },
-        "collapsable" : {
-          "description" : "True: the button can disappear when the screen real estate is too small.",
-          "type" : "boolean"
-        },
-        "webMinWidth" : {
-          "description" : "For Web (e.g. HTML5) players. If the button doesn't have this much room, and 'collapsable' is true then the button becomes hidden.",
-          "type" : "number"
-        },
-        "sdkMinWidth" : {
-          "description" : "For Mobile SDK App (i.e. Android, iOS) players. If the button doesn't have this much room, and 'collapsable' is true then the button becomes hidden.",
-          "type" : "number"
-        }          
+        "appearance" : { "$ref" : "#/definitions/buttonAppearance" },
+        "minWidth" : { "type" : "number" }
       }
+    },
+    "buttonAppearance" : {
+      "description" : "Specify where a button might appear in the UI. Both means it will collapse from the controlBar to the moreOptions panel. None means it is disabled entirely.",
+      "enum" : ["controlBar", "moreOptions", "both", "none"]
+    },
+    "buttonArray" : {
+      "description" : "Used to list the buttons for a single platform (desktop vs. mobile).",
+      "type" : "array",
+      "items" : { "$ref" : "#/definitions/button" }
     },
     "icon" : {
       "description" : "Icons are renderable from fonts. Bitmaps are not supported.",

--- a/skin.json
+++ b/skin.json
@@ -26,19 +26,6 @@
   "controlBar": {
     "autoHide": true,
     "height": 60,
-    "items": [
-      { "name" : "playPause", "collapsable" : false, "webMinWidth" : 25, "sdkMinWidth" : 25 },
-      { "name" : "volume", "collapsable" : true, "webMinWidth" : 100, "sdkMinWidth" : 25 },
-      { "name" : "timeDuration", "collapsable" : true, "webMinWidth" : 140, "sdkMinWidth" : 25 },
-      { "name" : "flexibleSpace", "collapsable" : false, "webMinWidth" : 1, "sdkMinWidth" : 1 },
-      { "name" : "quality", "collapsable" : true, "webMinWidth" : 25, "sdkMinWidth" : 25 },
-      { "name" : "share", "collapsable" : true, "webMinWidth" : 25, "sdkMinWidth" : 25 },
-      { "name" : "discovery", "collapsable" : true, "webMinWidth" : 25, "sdkMinWidth" : 25 },
-      { "name" : "closedCaption", "collapsable" : true, "webMinWidth" : 25, "sdkMinWidth" : 25 },
-      { "name" : "watermark", "collapsable" : false, "webMinWidth" : 120, "sdkMinWidth" : 120 },
-      { "name" : "fullscreen", "collapsable" : false, "webMinWidth" : 25, "sdkMinWidth" : 25 },
-      { "name" : "moreOptions", "collapsable" : false, "webMinWidth" : 25, "sdkMinWidth" : 25 }
-    ],
     "watermark": {
       "imageResource": { "url" : "http://static1.squarespace.com/static/520df253e4b04f7fbda9c4d9/t/55084401e4b07c3c95d3882f/1426605058603/unnamed.png" },
       "width": 500,
@@ -62,8 +49,7 @@
     "brightOpacity": 1.0,
     "darkOpacity": 0.4,
     "iconSize": 30,
-    "color": "white",
-    "buttons": ["discovery", "quality", "closedCaption", "share", "settings"]
+    "color": "white"
   },
   "discoveryScreen" : {
     "panelTitle": {
@@ -79,6 +65,32 @@
   "ccOptions": {
     "defaultEnabled": true,
     "defaultLanguage": "en"
+  },
+  "buttons" : {
+    "desktop" : [
+      { "name":"playPause", "appearance":"controlBar", "minWidth":25 },
+      { "name":"volume", "appearance":"both", "minWidth":100 },
+      { "name":"timeDuration", "appearance":"both", "minWidth":140 },
+      { "name":"flexibleSpace", "appearance":"controlBar", "minWidth":1 },
+      { "name":"quality", "appearance":"both", "minWidth":25 },
+      { "name":"share", "appearance":"both", "minWidth":25 },
+      { "name":"discovery", "appearance":"both", "minWidth":25 },
+      { "name":"closedCaption", "appearance":"both", "minWidth":25 },
+      { "name":"watermark", "appearance":"controlBar", "minWidth":120 },
+      { "name":"fullscreen", "appearance":"controlBar", "minWidth":25 },
+      { "name":"moreOptions", "appearance":"controlBar", "minWidth":25 }
+    ],
+    "mobile": [
+      { "name":"volume", "appearance":"both", "minWidth":25 },
+      { "name":"timeDuration", "appearance":"both", "minWidth":140 },
+      { "name":"flexibleSpace", "appearance":"controlBar", "minWidth":1 },
+      { "name":"quality", "appearance":"moreOptions", "minWidth":25 },
+      { "name":"share", "appearance":"moreOptions", "minWidth":25 },
+      { "name":"discovery", "appearance":"moreOptions", "minWidth":25 },
+      { "name":"closedCaption", "appearance":"moreOptions", "minWidth":25 },
+      { "name":"fullscreen", "appearance":"controlBar", "minWidth":25 },
+      { "name":"moreOptions", "appearance":"controlBar", "minWidth":25 }
+    ]
   },
   "icons" : {
     "play" : { "fontFamilyName": "fontawesome", "fontString" : "\uf04b" },


### PR DESCRIPTION
NOTE: this actually is branched from https://github.com/ooyala/skin-config/pull/46 so merge that first please!!!!!!!!!!!!!!

We've been trying to debate & decide exactly how this should be done. I did experiment with 3 different flavors:

(1) A single button spec includes everything for desktop and mobile, like { name, platform, desktopAppearance, mobileAppearance, desktopMinWidth, mobileMinWidth }. That doesn't work well given that there's no play button on either controlBar or moreOptions for mobile. And it is hard to read in the skin.json file.

(2) A single button spec has 2 sub-specs, one for each platform. This reads better than (1) in the skin.json, but it falls down over the same issue with the play button.

(3) what we have here, I feel like it is the least bad / most self-documenting / most able to use the schema to be clear and careful.
