### PR TITLE
[PBA-3004] Remove color keys for more options screen

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -109,11 +109,9 @@
     "color": "white",
     "iconStyle": {
       "active": {
-        "color": "#FFFFFF",
         "opacity": 1
       },
       "inactive": {
-        "color": "#FFFFFF",
         "opacity": 0.6
       }
     }


### PR DESCRIPTION
In more options screen, the styling for the icons do not need the color key in the ios-skin repo. Could someone confirm if this key is relevant for Android and web?