### PR TITLE
Simplify Discovery Fonts to just Roboto

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -81,7 +81,7 @@
     "panelTitle": {
       "titleFont": {
         "fontSize": 28,
-        "fontFamily": "'Roboto Condensed', sans-serif",
+        "fontFamily": "Roboto Condensed",
         "color": "white"
       }
     },
@@ -89,7 +89,7 @@
       "show": true,
       "font": {
         "fontSize": 22,
-        "fontFamily": "'Roboto Condensed', sans-serif",
+        "fontFamily": "Roboto Condensed",
         "color": "white"
       }
     },


### PR DESCRIPTION
Hey @chibzu  

Do you think this would be okay?  Can you try (1) if this skin config works okay for you, and (2) how the fallback behavior works (does it naturally go to a sans-serif font by default?)  This would save a ton of headache on our side