### PR TITLE
[PBW-5518] remove ooyala logo from default skin.json

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -160,7 +160,7 @@
     "autoHide": true,
     "height": 90,
     "logo": {
-      "imageResource": {"url": "//player.ooyala.com/static/v4/candidate/latest/skin-plugin/assets/images/ooyala-logo.svg","androidResource" : "logo","iosResource" : "logo"},
+      "imageResource": {"url": "","androidResource": "logo","iosResource": "logo"},
       "clickUrl": "http://www.ooyala.com",
       "target": "_blank",
       "width": 96,


### PR DESCRIPTION
html5-skin is design to [exclude logo](https://github.com/ooyala/html5-skin/blob/stable/js/components/controlBar.js#L400) if there is no imageResource url.

This approach allows customers to continue to use custom logo if needed.