### PR TITLE
[PBW-5932] - Removing ghost property and remaining fontSize entries

### DIFF
--- a/skin-schema.json
+++ b/skin-schema.json
@@ -349,20 +349,6 @@
             "font": {"$ref": "#/definitions/fontStyle"}
           }
         },
-        "contentDuration": {
-          "description": "The setting for Discovery content duration.",
-          "type": "object",
-          "additionalProperties": false,
-          "required": [ "show", "font"],
-          "properties": {
-            "show": {
-              "description": "Set to true to display the video duration on the Discovery screen, set to false otherwise.",
-              "type": "boolean",
-              "default": true
-            },
-            "font": {"$ref": "#/definitions/fontStyle"}
-          }
-        },
         "showCountDownTimerOnEndScreen": {
           "description": "Whether or not to show the countdown timer for autoplay.",
           "type": "boolean",
@@ -1187,8 +1173,7 @@
           "description": "Any valid CSS color value (named colors, three-digit hex color, six-digit hex color, RGB colors).",
           "type": "string"
         },
-        "weight": {"type": "string"},
-        "fontSize": {"type": "number"}
+        "weight": {"type": "string"}
       }
     }
   }

--- a/skin.json
+++ b/skin.json
@@ -81,7 +81,6 @@
   "discoveryScreen": {
     "panelTitle": {
       "titleFont": {
-        "fontSize": 28,
         "fontFamily": "Roboto Condensed",
         "color": "white"
       }
@@ -89,16 +88,7 @@
     "contentTitle": {
       "show": true,
       "font": {
-        "fontSize": 22,
         "fontFamily": "Roboto Condensed",
-        "color": "white"
-      }
-    },
-    "contentDuration": {
-      "show": true,
-      "font": {
-        "fontSize": 12,
-        "fontFamily": "Arial-BoldMT",
         "color": "white"
       }
     },


### PR DESCRIPTION
Removed `discoveryScreen.contentDuration` property since it's not implemented by PBW or PBA. Also removed references to `fontSize` since supporting these would break responsiveness in the web player (`fontSize` is currently ignored on the html5-skin, btw). @lental need your help confirming that this change doesn't affect PBA, thanks.
