### PR TITLE
Added platform support information to accentColor in skin-schema.json.

### DIFF
--- a/skin-schema.json
+++ b/skin-schema.json
@@ -58,7 +58,11 @@
         },
         "accentColor": {
           "description": "Any valid CSS color value (named colors, three-digit hex color, six-digit hex color, RGB colors).",
-          "type": "string"
+          "type": "string",
+	      "platform support": {
+	          "iOS SDK": "v4.21.0+",
+	          "Android SDK": "v4.21.0+ Note: the toggle switch color cannot be customized"
+	      }
         }
       }
     },


### PR DESCRIPTION
        "accentColor": {
          "description": "Any valid CSS color value (named colors, three-digit hex color, six-digit hex color, RGB colors).",
          "type": "string",
	      "platform support": {
	          "iOS SDK": "v4.21.0+",
	          "Android SDK": "v4.21.0+ Note: the toggle switch color cannot be customized"
	      }
        }
      }