### PR TITLE
[PLAYER-816] Added missing Japanese language references to schema

### DIFF
--- a/skin-schema.json
+++ b/skin-schema.json
@@ -73,18 +73,18 @@
         "defaultLanguage": {
           "description": "The default language of the localizable strings on the player.",
           "type": "string", "pattern": "^[a-z]{2}$",
-          "valid values": "\"en\", \"es\", \"zh\"",
+          "valid values": "\"en\", \"es\", \"zh\", \"ja\"",
           "default": "en"
         },
         "availableLanguageFile": {
           "description": "An array of languages. Defines the string values used in the player. Languages listed in the array require a separate json file included in the bundle, named '<language>.json' e.g. 'en.json'.",
           "type": "array",
           "items": {"type": "object", "pattern": "^[a-z]{2}$"},
-          "default": "{\"language\": \"en\", \"languageFile\": \"config/en.json\"}, {\"language\": \"es\", \"languageFile\": \"config/es.json\"}, {\"language\": \"zh\", \"languageFile\": \"config/zh.json\"}",
+          "default": "{\"language\": \"en\", \"languageFile\": \"config/en.json\"}, {\"language\": \"es\", \"languageFile\": \"config/es.json\"}, {\"language\": \"zh\", \"languageFile\": \"config/zh.json\"}, {\"language\": \"ja\", \"languageFile\": \"config/ja.json\"}",
           "language": {
-            "description": "Defines the language. For this release, valid languages are English (en), Spanish (es), and Simplified Chinese (zh).",
+            "description": "Defines the language. For this release, valid languages are English (en), Spanish (es), Simplified Chinese (zh) and Japanese (ja).",
             "type": "string",
-            "valid values": "\"en\" | \"es\" | \"zh\""
+            "valid values": "\"en\" | \"es\" | \"zh\" | \"ja\""
           },
           "languageFile": {
             "description": "Path to the localized language file.",


### PR DESCRIPTION
I missed adding these when we update the language files.