### PR TITLE
[bugfix/PLAYER-3316] Remove default audio parameter 

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -227,9 +227,6 @@
     "vrNotification": true,
     "vrIcon": false
   },
-  "audio": {
-    "audioLanguage": "en"
-  },
   "animationDurations": {
     "vrNotification": 5,
     "vrIcon": 4


### PR DESCRIPTION
Fixes issue where default audio track set in skin.json was overwriting custom skin.json defined by user.