### PR TITLE
[PLAYER-3475] Adding configuration options for skip buttons

### DIFF
--- a/skin-schema.json
+++ b/skin-schema.json
@@ -542,11 +542,11 @@
               "$ref": "#/definitions/skipControlsButton"
             },
             "skipBackward": {
-              "description": "Button that allows skipping a few seconds backward in the video.",
+              "description": "Button that allows skipping the video backward the amount of seconds defined in \"skipBackwardTime\".",
               "$ref": "#/definitions/skipControlsButton"
             },
             "skipForward": {
-              "description": "Button that allows skipping a few seconds forward in the video.",
+              "description": "Button that allows skipping the video forward the amount of seconds defined in \"skipForwardTime\".",
               "$ref": "#/definitions/skipControlsButton"
             },
             "nextVideo": {

--- a/skin-schema.json
+++ b/skin-schema.json
@@ -512,6 +512,51 @@
         }
       }
     },
+    "skipControls": {
+      "description": "Toolbar which contains buttons that allow skipping back or forward and switching to the previous or next videos.",
+      "type": "object",
+      "required": [ "enabled", "skipBackwardTime", "skipForwardTime", "buttons" ],
+      "properties": {
+        "enabled": {
+          "description": "Show the \"Skip Controls\" toolbar if set to true, hide if set to false.",
+          "type": "boolean"
+        },
+        "skipBackwardTime": {
+          "description": "An integer number ranging from 1 to 60. Controls the amount of seconds that the playhead moves when the \"Skip Backward\" button is clicked.",
+          "type": "number",
+          "minimum": 1,
+          "maximum": 60
+        },
+        "skipForwardTime": {
+          "description": "An integer number ranging from 1 to 60. Controls the amount of seconds that the playhead moves when the \"Skip Forward\" button is clicked.",
+          "type": "number",
+          "minimum": 1,
+          "maximum": 60
+        },
+        "buttons": {
+          "description": "The collection of buttons that can be displayed on the \"Skip Controls\" toolbar.",
+          "type": "object",
+          "properties": {
+            "previousVideo": {
+              "description": "Button that allows switching to the last video that was played or to the previous video in a playlist.",
+              "$ref": "#/definitions/skipControlsButton"
+            },
+            "skipBackward": {
+              "description": "Button that allows skipping a few seconds backward in the video.",
+              "$ref": "#/definitions/skipControlsButton"
+            },
+            "skipForward": {
+              "description": "Button that allows skipping a few seconds forward in the video.",
+              "$ref": "#/definitions/skipControlsButton"
+            },
+            "nextVideo": {
+              "description": "Button that allows switching to the next video recommendation or to the next video in a playlist.",
+              "$ref": "#/definitions/skipControlsButton"
+            }
+          }
+        }
+      }
+    },
     "controlBar": {
       "description": "The playback control bar. Generally contains a play-pause button, scrubber control, etc. The set of items to show comes from the 'buttons' part of the schema.",
       "type": "object",
@@ -796,7 +841,7 @@
         "\"learn\": { \"fontFamilyName\": \"alice\", \"fontString\": \"\\u0074\", \"fontStyleClass\": \"icon icon-learn\"},",
         "\"skip\": { \"fontFamilyName\": \"alice\", \"fontString\": \"\\u0075\", \"fontStyleClass\": \"icon icon-skip\"}",
         "\"audioAndCC\": { \"fontFamilyName\": \"alice\", \"fontString\": \"\\u005F\", \"fontStyleClass\": \"icon icon-audio-and-cc\"}",
-        "\"selected\": { \"fontFamilyName\": \"alice\", \"fontString\": \"\\u0040\", \"fontStyleClass\": \"icon icon-selected\"}",            
+        "\"selected\": { \"fontFamilyName\": \"alice\", \"fontString\": \"\\u0040\", \"fontStyleClass\": \"icon icon-selected\"}",
         "}"],
       "play": {
         "description": "Set the styling for the play icon on mobile devices.",
@@ -1315,6 +1360,23 @@
       "description": "Used to list the buttons for a single platform (desktop vs. mobile).",
       "type": "array",
       "items": { "$ref": "#/definitions/button" }
+    },
+    "skipControlsButton": {
+      "description": "Buttons displayed on the \"Skip Controls\" toolbar.",
+      "type": "object",
+      "required": [ "enabled", "index" ],
+      "properties": {
+        "enabled": {
+          "description": "Show the button if set to true, hide if set to false.",
+          "type": "boolean"
+        },
+        "index": {
+          "description": "An integer number which determines the order in which the button will be shown within the toolbar. Buttons are sorted in ascending order.",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
     },
     "icon": {
       "description": "Icons are renderable from fonts. Bitmaps are not supported.",

--- a/skin.json
+++ b/skin.json
@@ -177,8 +177,26 @@
   },
   "skipControls": {
     "enabled": true,
-    "skipBackwardsTime": 10,
-    "skipForwardTime": 10
+    "skipBackwardTime": 10,
+    "skipForwardTime": 10,
+    "buttons": {
+      "previousVideo": {
+        "enabled": true,
+        "index": 1
+      },
+      "skipBackward": {
+        "enabled": true,
+        "index": 2
+      },
+      "skipForward": {
+        "enabled": true,
+        "index": 3
+      },
+      "nextVideo": {
+        "enabled": true,
+        "index": 4
+      }
+    }
   },
   "controlBar": {
     "volumeControl": {

--- a/skin.json
+++ b/skin.json
@@ -175,6 +175,11 @@
     "showUpNext": true,
     "timeToShow": 10
   },
+  "skipControls": {
+    "enabled": true,
+    "skipBackwardsTime": 10,
+    "skipForwardTime": 10
+  },
   "controlBar": {
     "volumeControl": {
       "color": ""


### PR DESCRIPTION
With these changes, the user will be able to:

- Show or hide skip buttons entirely
- Configure the amount of seconds to skip forward and backward
- Configure the individual buttons that are shown, as well as their order

The default values haven't been determined yet, so these are just placeholders. We will also need another PR in order to add the new icons.

There are some drawbacks to the proposed structure which we should consider:

- We assume that all skip buttons are within a single component. This is true now, but it might change in the future.
- The way the skip buttons are declared is inconsistent with how control bar buttons are declared. 

The reason that I chose this inconsistent approach is that it is much easier to override (i.e. you don't have to specify the whole list of buttons in order to change one) and we're likely not going to support the same properties that control bar buttons support (such as different options for desktop/mobile, min-width, move to more options, etc.), but let me know if you think we should go a different route.