### PR TITLE
[PLAYER-4498][PLAYER-4499] Remove playbackSpeed button by default on mobileContent

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -321,7 +321,6 @@
       {"name":"discovery", "location":"moreOptions" },
       {"name":"closedCaption", "location":"moreOptions" },
       {"name":"stereoscopic", "location":"controlBar", "whenDoesNotFit":"keep", "minWidth":50 },
-      {"name":"playbackSpeed", "location": "controlBar", "whenDoesNotFit":"keep", "minWidth":50 },
       {"name":"audioAndCC", "location": "controlBar", "whenDoesNotFit":"keep", "minWidth":50 },
       {"name":"fullscreen", "location":"controlBar", "whenDoesNotFit":"keep", "minWidth":50 },
       {"name":"moreOptions", "location":"controlBar", "whenDoesNotFit":"keep", "minWidth":50 }


### PR DESCRIPTION
Be the same as web, playbackSpeed menu disabled by default.