### PR TITLE
[PLAYER-4114] Add airplay button into skin-schema to pass validation.

### DIFF
--- a/skin-schema.json
+++ b/skin-schema.json
@@ -1439,6 +1439,7 @@
                "bitrateSelector",
                "skipControls",
                "chromecast",
+               "airPlay",
                "seekBackwards",
                "seekForward"]
     },


### PR DESCRIPTION
It was necessary to add AirPlay button to Web Player UI. 
The button is added, but skin-schema wasn't updated and validation of skin.json fails.
I add "airPlay" into buttons enum to let validate skin.json.

![skin-config_—_-bash_—_158×24](https://user-images.githubusercontent.com/32324899/54341601-41169000-464b-11e9-8e7c-1e31df92091c.jpg)
