### PR TITLE
[PLAYER-5411] Added button for 'Picture in picture' and it's icons

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -356,7 +356,8 @@
       {"name":"stereoscopic", "location":"controlBar", "whenDoesNotFit":"moveToMoreOptions", "minWidth":28 },
       {"name":"audioAndCC", "location": "controlBar", "whenDoesNotFit":"moveToMoreOptions", "minWidth":28 },
       {"name":"fullscreen", "location":"controlBar", "whenDoesNotFit":"moveToMoreOptions", "minWidth":28 },
-      {"name":"moreOptions", "location":"controlBar", "whenDoesNotFit":"keep", "minWidth":28 }
+      {"name":"moreOptions", "location":"controlBar", "whenDoesNotFit":"keep", "minWidth":28 },
+      {"name":"pipButton", "location": "controlBar", "whenDoesNotFit":"moveToMoreOptions", "minWidth":28 }
     ],
     "mobileAd": [
       {"name":"volume", "location":"controlBar", "whenDoesNotFit":"keep", "minWidth":28 },
@@ -422,6 +423,8 @@
     "chromecast-connected": {"fontFamilyName": "ooyala-slick-type", "fontString": "\u003B", "fontStyleClass": "oo-icon"},
     "chromecast-disconnected": {"fontFamilyName": "ooyala-slick-type", "fontString": "\u003A", "fontStyleClass": "oo-icon"},
     "airPlay-connected": {"fontFamilyName": "ooyala-slick-type", "fontString": "\u007C", "fontStyleClass": "oo-icon"},
-    "airPlay-disconnected": {"fontFamilyName": "ooyala-slick-type", "fontString": "\u007B", "fontStyleClass": "oo-icon"}
+    "airPlay-disconnected": {"fontFamilyName": "ooyala-slick-type", "fontString": "\u007B", "fontStyleClass": "oo-icon"},
+    "pipInButton": {"fontFamilyName": "ooyala-slick-type", "fontString": "\u002B", "fontStyleClass": "oo-icon"},
+    "pipOutButton": {"fontFamilyName": "ooyala-slick-type", "fontString": "\u002C", "fontStyleClass": "oo-icon"}
   }
 }


### PR DESCRIPTION
**Ticket goal:** Show icons for Picture-in-picture button (when feature is available)
**How PR achieves the goal:** In file skin.json I added new button into "buttons" -> "mobileContent" and two icons
**Affected repo-s:** skin-config, SkinSDK(branch PLAYER-5411) (Fonts, iOS-SDK are already merged)
**Unit tests:** Unit test not added
**SampleApp for testing**: Picture-inPicture in ticket description