### PR TITLE
PBW-8120 play icon now shown correcly for RTL direction

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -385,7 +385,7 @@
     }
   },
   "icons": {
-    "play": {"fontFamilyName": "ooyala-slick-type", "fontString": "\u003e", "fontStyleClass": "oo-icon oo-icon-play-slick"},
+    "play": {"fontFamilyName": "ooyala-slick-type", "fontString": "\u0076", "fontStyleClass": "oo-icon oo-icon-play-slick"},
     "pause": {"fontFamilyName": "ooyala-slick-type", "fontString": "\u0067", "fontStyleClass": "oo-icon oo-icon-pause-slick"},
     "volume": {"fontFamilyName": "ooyala-slick-type", "fontString": "\u0062", "fontStyleClass": "oo-icon oo-icon-volume-on-ooyala-default"},
     "volumeOff": {"fontFamilyName": "ooyala-slick-type", "fontString": "\u0070", "fontStyleClass": "oo-icon oo-icon-volume-mute-ooyala-default"},


### PR DESCRIPTION
Occasionally for `play` icon invalid sign was used, like this `>|`, which usually means forward to next asset. We didn't notice this because the char is a bit shifted right from own cell so that the right vertical line was out of the cell and didn't appear. But it reveals for RTL display mode.
I've just addressed `play` button to a correct char in the font.